### PR TITLE
fixed deprecated use of strftime

### DIFF
--- a/disakt.py
+++ b/disakt.py
@@ -55,11 +55,11 @@ while True:
         starttime = data['started_at']
         starttime = dp.parse(starttime)
         starttime = starttime.astimezone(est)
-        starttime = starttime.strftime('%s')
+        starttime = starttime.timestamp()
         endtime = data['expires_at']
         endtime = dp.parse(endtime)
         endtime = endtime.astimezone(est)
-        endtime = endtime.strftime('%s')
+        endtime = endtime.timestamp()
         print(starttime, endtime)
         updateRPC(newstate, newdetails, starttime, endtime, media)
     except:


### PR DESCRIPTION
As per described [here](https://stackoverflow.com/questions/11743019/convert-python-datetime-to-epoch-with-strftime), `timestamp()` should be used in lieu of `strftime('%s')`.